### PR TITLE
Copyright year 2022, update repository URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks to all the amazing people for all your wonderful PRs, issues and ideas, all contributions are welcome!
 
-We are using [next](https://github.com/pavanjadhaw/betterlockscreen/tree/next) as our development-branch and master for the latest stable release. Please provide your pull-requests based on our next-branch.
+We are using [next](https://github.com/betterlockscreen/betterlockscreen/tree/next) as our development-branch and master for the latest stable release. Please provide your pull-requests based on our next-branch.
 
 For Nix-Users: We provide a nix-shell for development :-)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Pavan Jadhaw, and others (https://github.com/pavanjadhaw/betterlockscreen/graphs/contributors)
+Copyright (c) 2017-2022 Pavan Jadhaw, and others (https://github.com/betterlockscreen/betterlockscreen/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-# Author : Copyright (c) 2017-2021 Pavan Jadhaw, and others (https://github.com/pavanjadhaw/betterlockscreen/graphs/contributors)
-# Github Profile : https://github.com/pavanjadhaw
-# Project Repository : https://github.com/pavanjadhaw/betterlockscreen
+# Author : Copyright (c) 2017-2022 Pavan Jadhaw, and others (https://github.com/betterlockscreen/betterlockscreen/graphs/contributors)
+# Project Repository : https://github.com/betterlockscreen/betterlockscreen
 
 cmd_exists () {
     command -v "$1" >/dev/null

--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ fi
 
 BLI_TEMP_DIR=$(mktemp -d)
 
-git clone -b "$VERSION" https://github.com/pavanjadhaw/betterlockscreen "$BLI_TEMP_DIR" &>/dev/null
+git clone -b "$VERSION" https://github.com/betterlockscreen/betterlockscreen "$BLI_TEMP_DIR" &>/dev/null
 cd "$BLI_TEMP_DIR" || exit 1
 
 echof info "Installing Betterlockscreen to '$BL_INSTALL_DIR'... "


### PR DESCRIPTION
# Description

This PR updates the copyright year to 2022 and updates the repository URL to github.com/betterlockscreen/betterlockscreen.

There are still many references to `github.com/pavanjadhaw/betterlockscreen` in the README, but many of them point to external services I have no control over. These changes should probably be made by someone closer to the project.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
