### PR TITLE
Run prelock and postlock synchronously to avoid race condition

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -278,7 +278,7 @@ postlock() {
 lockselect() {
 
     echof act "Running prelock..."
-    prelock &
+    prelock
 
     case "$1" in
         dim) if [ -f "$CUR_L_DIM" ]; then lock "$CUR_L_DIM"; else failsafe; fi ;;
@@ -291,7 +291,7 @@ lockselect() {
     esac
 
     echof act "Running postlock..."
-    postlock &
+    postlock
 }
 
 # calculate adjustments for hidpi displays


### PR DESCRIPTION
# Description

As reported in issue #285, running postlock in a subshell and immediately returning from lockselect() has a high chance of hitting `exit 0` before xset and dunstctl get a chance to execute.

Run both prelock and postlock synchronously within lockselect().

Fixes #285 

# How Has This Been Tested?

Running with `set -x` shows both xset and dunstctl executing reliably as expected, and `xset q` shows the original DPMS standby time after a succesful unlock.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
       There are 2 existing errors unrelated to my changes:
```
In betterlockscreen line 610:
        local position="${geometry#*${cols[1]}}"
                                    ^--------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

In betterlockscreen line 611:
        local resolution="${geometry%${position}*}"
                                     ^---------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.
```

- [ ] I have made corresponding changes to the documentation (if applicable)