### PR TITLE
Fixed DPMS not being set when using -s

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -113,10 +113,6 @@ prelock() {
     if [[ "$DUNST_INSTALLED" == "true" && "$DUNST_IS_PAUSED" == "false" ]]; then
         dunstctl set-paused true
     fi
-
-    if [[ "$runsuspend" = "true" ]]; then
-        lockargs="$lockargs -n"
-    fi
 }
 
 # lock screen with specified image
@@ -274,11 +270,23 @@ postlock() {
 
 
 # select effect and lock screen
-lockselect() {
-
+lockinit() {
     echof act "Running prelock..."
     prelock
 
+    if [[ $runsuspend ]]; then 
+        lockselect "$@" &
+        systemctl suspend
+        wait $!
+    else
+        lockselect "$@"
+    fi
+
+    echof act "Running postlock..."
+    postlock
+}
+
+lockselect() {
     case "$1" in
         dim) if [ -f "$CUR_L_DIM" ]; then lock "$CUR_L_DIM"; else failsafe; fi ;;
         blur) if [ -f "$CUR_L_BLUR" ]; then lock "$CUR_L_BLUR"; else failsafe; fi ;;
@@ -288,9 +296,6 @@ lockselect() {
         color) if [ -f "$CUR_L_COLOR" ]; then lock "$CUR_L_COLOR"; else failsafe; fi ;;
         *) if [ -f "$CUR_L_RESIZE" ]; then lock "$CUR_L_RESIZE"; else failsafe; fi ;;
     esac
-
-    echof act "Running postlock..."
-    postlock
 }
 
 # calculate adjustments for hidpi displays
@@ -966,8 +971,7 @@ echof header "Betterlockscreen"
 [[ $runupdate ]] && update "${imagepaths[@]}"
 
 # Activate lockscreen
-[[ $runsuspend ]] || lockargs+=(-n)
-[[ $runlock ]] && lockselect "$lockstyle" && \
-    { [[ $runsuspend ]] && systemctl suspend; }
+lockargs+=(-n)
+[[ $runlock ]] && lockinit "$lockstyle" 
 
 exit 0


### PR DESCRIPTION
This fixes issue #324
DPMS now works as expected when using -s / --suspend

# Description

When we use -s, lock the screen as a background process and suspend.
Then, wait for the lock process to end (user enters password), before running postrun.

# How Has This Been Tested?

I ran the following:

    betterlockscreen -l
    betterlockscreen -l --off X
    betterlockscreen -s
    betterlockscreen -s --off X

They all ran as expected, and set DPMS correctly.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [ ] I have made corresponding changes to the documentation (if applicable)
