### PR TITLE
Improve and extend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,15 +120,14 @@ systemctl enable betterlockscreen@$USER
 
 ## Configuration
 
-You can customize Betterlockscreen for your needs, copy the config file from the examples-directory to `~/.config/betterlockscreenrc` and edit it accordingly.
-
-If no configuration-file is found, then the default configurations (which is equal to the example but currently hardcoded) will be used.
-
-If you have installed betterlockscreen from AUR package, then you can copy default config from docs
+You can customize Betterlockscreen for your needs, copy the config file from the examples-directory to the user-configuration directory `~/.config/betterlockscreen/` and edit it accordingly.
 
 ```sh
-cp /usr/share/doc/betterlockscreen/examples/betterlockscreenrc ~/.config
+mkdir -p ~/.config/betterlockscreen/
+cp /usr/share/doc/betterlockscreen/examples/betterlockscreenrc ~/.config/betterlockscreen/
 ```
+
+If no configuration-file is found, then the default configurations (which is equal to the example but hardcoded) will be used.
 
 ## Usage
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -20,6 +20,7 @@ init_config () {
     description=""
     quiet=false
     i3lockcolor_bin="i3lock-color"
+    suspend_command="systemctl suspend"
 
     if ! cmd_exists "$i3lockcolor_bin" && cmd_exists "i3lock"; then
         i3lockcolor_bin="i3lock"
@@ -48,13 +49,29 @@ init_config () {
     modifcolor=d23c3dff
     bgcolor=000000ff
     wallpaper_cmd="feh --bg-fill"
-    time_format="%H:%M:%S"
 
     # read user config
-    USER_CONF="${XDG_CONFIG_HOME:-$HOME/.config}/betterlockscreenrc"
+    USER_CONF_DIR="${XDG_CONFIG_HOME:-$HOME/.config}"
+    USER_CONF="$USER_CONF_DIR/betterlockscreenrc"
+    SYS_CONF="/etc/betterlockscreenrc"
+    XDG_USER_CONF="$USER_CONF_DIR/betterlockscreen/betterlockscreenrc"
+
+    if [ -e "$SYS_CONF" ]; then
+        # shellcheck source=/dev/null
+        source "$SYS_CONF"
+    fi
+
     if [ -e "$USER_CONF" ]; then
+        echof error "Please, migrate your config $USER_CONF to $XDG_USER_CONF. Old location will soon be deprecated."
+        echof info "mkdir -p ~/.config/betterlockscreen/ && mv $USER_CONF $XDG_USER_CONF"
+
         # shellcheck source=/dev/null
         source "$USER_CONF"
+    fi
+
+    if [ -e "$XDG_USER_CONF" ]; then
+        # shellcheck source=/dev/null
+        source "$XDG_USER_CONF"
     fi
 
     if ! cmd_exists "$i3lockcolor_bin"; then
@@ -267,7 +284,7 @@ lockinit() {
 
     if [[ $runsuspend ]]; then 
         lockselect "$@" &
-        systemctl suspend
+        $suspend_command
         wait $!
     else
         lockselect "$@"
@@ -813,6 +830,8 @@ usage() {
     exit 1
 }
 
+lockargs+=(-n)
+
 init_config
 
 # show usage when no arguments passed
@@ -954,7 +973,6 @@ echof header "Betterlockscreen"
 [[ $runupdate ]] && update "${imagepaths[@]}"
 
 # Activate lockscreen
-lockargs+=(-n)
 [[ $runlock ]] && lockinit "$lockstyle" 
 
 exit 0

--- a/examples/betterlockscreenrc
+++ b/examples/betterlockscreenrc
@@ -11,7 +11,6 @@ pixel_scale=10,1000
 solid_color=333333
 wallpaper_cmd="feh --bg-fill"
 quiet=false
-# i3lockcolor_bin="i3lock-color" # Manually set command for i3lock-color
 
 # default theme
 loginbox=00000066
@@ -35,3 +34,15 @@ verifcolor=ffffffff
 wrongcolor=d23c3dff
 modifcolor=d23c3dff
 bgcolor=000000ff
+
+
+#
+# expert options (change at own risk!)
+#
+
+# i3lockcolor_bin="i3lock-color"      # Manually set command for i3lock-color
+# suspend_command="systemctl suspend" # Manually change action e.g. hibernate/suspend-command
+
+# i3lock-color - custom arguments
+# lockargs=() 						  # overwriting default "(-n)"
+# lockargs+=(--ignore-empty-password) # appending new argument


### PR DESCRIPTION
# Description

* Parse system-config (/etc/betterlockscreenrc) if present
* Deprecate user-config path to switch to fully xdg-compliant
* Change initial declaration of locker-args to make it overwriteable in config
* Remove old (invalid) AUR hint in docs

Fixes #137, #174, #188, #323

# How Has This Been Tested?

ShellCheck, combined tested code from #362, #293 

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
