### PR TITLE
Systemd Service Should Be Type "forking"

### DIFF
--- a/system/betterlockscreen@.service
+++ b/system/betterlockscreen@.service
@@ -5,7 +5,7 @@ Before=suspend.target
 
 [Service]
 User=%I
-Type=simple
+Type=forking
 Environment=DISPLAY=:0
 ExecStart=/usr/local/bin/betterlockscreen --lock
 TimeoutSec=infinity


### PR DESCRIPTION
# Description
On my laptop (specs below), betterlockscreen will be be bale to lock properly if set to be `type=simple.` The reason is because the service will detect sleep or suspend event, then execute lock, then exit since execution is successful, and kill the lock program altogether. Under `forking`, the service file will execute lock program and exit without killing the lock, keeping it alive until user intervention (password input) clears the forked process.

I got the idea to change to forking from [this](https://wiki.archlinux.org/title/Power_management#Suspend/resume_service_files) page of the arch wiki.

Hopefully I made a sensible change in the right place.

# How Has This Been Tested?

Close lid, locking with key binding.

# Specifications
Thinkpad W550s
i3wm
Arch Linux

# Checklist:

- [x ] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [ x] I have made corresponding changes to the documentation (if applicable)
