### PR TITLE
Refuse to run if i3lock is already running

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -291,6 +291,11 @@ postlock() {
 
 # select effect and lock screen
 lockinit() {
+    if pgrep -u "$USER" i3lock; then
+        echof error "i3lock already running"
+        exit 1
+    fi
+
     echof act "Running prelock..."
     prelock
 


### PR DESCRIPTION
# Description

`betterlockscreen` now refuses to run if a process with name including `i3lock` is already running by the same user (as otherwise running `i3lock` again fails with `i3lock: Cannot grab pointer/keyboard`).

This primarily fixes a minor gripe I had where betterlockscreen would attempt to run twice when I put computer to sleep (once from the systemd service and once from xautolock). This was particularly annoying when, for some reason (probably a sort of race condition), dpms would not be reset correctly.

It might be desirable to change how it detects whether it is already running. Maybe checking based on `$i3lockcolor_bin` or just checking for `betterlockscreen` itself? Additionally, this will probably run into issues (untested) when running betterlockscreen on multiple `$DISPLAY`s at once as the same user, as any subsequent ones will fail. We could probably try to detect what `$DISPLAY` the `i3lock` (or whatever) process is on, but that sounds like a lot of hassle, so maybe just adding a config option to disable this check would be easier. I'd be fine with implementing any of these changes if so desired.

# How Has This Been Tested?

- Tried running betterlockscreen by itself and it worked as normal
- Tried running betterlockscreen twice and i3lock only ran once
- Tried putting my computer to sleep and i3lock only ran once (see above)

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
