### PR TITLE
Having a directory within config doesn't work on Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,10 @@ systemctl enable betterlockscreen@$USER
 
 ## Configuration
 
-You can customize Betterlockscreen for your needs, copy the config file from the examples-directory to the user-configuration directory `~/.config/betterlockscreen/` and edit it accordingly.
+You can customize Betterlockscreen for your needs, copy the config file from the examples-directory to the user-configuration directory `~/.config/` and edit it accordingly.
 
 ```sh
-mkdir -p ~/.config/betterlockscreen/
-cp /usr/share/doc/betterlockscreen/examples/betterlockscreenrc ~/.config/betterlockscreen/
+cp /usr/share/doc/betterlockscreen/examples/betterlockscreenrc ~/.config/
 ```
 
 If no configuration-file is found, then the default configurations (which is equal to the example but hardcoded) will be used.


### PR DESCRIPTION
Having a directory for betterlockscreen within the .config directory makes betterlockscreen unable to find the betterlockscreenrc.

# How Has This Been Tested?

Tried using `-u` with the rc file in either location. This updates the documentation to reflect the location that works.