### PR TITLE
Bugfix #389 - Prepare v4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/betterlockscreen/betterlockscreen/actions/workflows/main.yml?query=branch%3Amain"><img alt="GitHub Workflow Status (main)" src="https://img.shields.io/github/actions/workflow/status/betterlockscreen/betterlockscreen/main.yml?branch=main&label=main&style=for-the-badge"></a>
   <a href="https://github.com/betterlockscreen/betterlockscreen/actions/workflows/main.yml?query=branch%3Anext"><img alt="GitHub Workflow Status (next)" src="https://img.shields.io/github/actions/workflow/status/betterlockscreen/betterlockscreen/main.yml?branch=next&label=next&style=for-the-badge"></a>
   <a href="https://github.com/betterlockscreen/betterlockscreen/milestone/2"><img alt="GitHub milestone" src="https://img.shields.io/github/milestones/progress/betterlockscreen/betterlockscreen/2?style=for-the-badge"></a>
-  <a href="https://github.com/betterlockscreen/betterlockscreen/compare/v4.1.0...next"><img alt="GitHub commits since latest release (by date) for a branch" src="https://img.shields.io/github/commits-since/betterlockscreen/betterlockscreen/v4.1.0/next?style=for-the-badge"></a>
+  <a href="https://github.com/betterlockscreen/betterlockscreen/compare/v4.2.0...next"><img alt="GitHub commits since latest release (by date) for a branch" src="https://img.shields.io/github/commits-since/betterlockscreen/betterlockscreen/v4.2.0/next?style=for-the-badge"></a>
   <a href="https://github.com/betterlockscreen/betterlockscreen/blob/main/LICENSE"><img src="https://img.shields.io/github/license/betterlockscreen/betterlockscreen.svg?style=for-the-badge"></a>
 </div>
 

--- a/betterlockscreen
+++ b/betterlockscreen
@@ -56,7 +56,8 @@ init_config () {
     USER_CONF_DIR="${XDG_CONFIG_HOME:-$HOME/.config}"
     USER_CONF="$USER_CONF_DIR/betterlockscreenrc"
     SYS_CONF="/etc/betterlockscreenrc"
-    XDG_USER_CONF="$USER_CONF_DIR/betterlockscreen/betterlockscreenrc"
+    XDG_USER_CONF_DIR="$USER_CONF_DIR/betterlockscreen"
+    XDG_USER_CONF="$XDG_USER_CONF_DIR/betterlockscreenrc"
 
     if [ -e "$SYS_CONF" ]; then
         # shellcheck source=/dev/null
@@ -82,7 +83,7 @@ init_config () {
     fi
 
     # Please make sure to adjust this before release!
-    VERSION="4.1.0"
+    VERSION="4.2.0"
 
     # paths
     CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/betterlockscreen"
@@ -131,9 +132,9 @@ prelock() {
         dunstctl set-paused true
     fi
 
-    if [ -e "$USER_CONF_DIR/custom-pre.sh" ]; then
+    if [ -e "$XDG_USER_CONF_DIR/custom-pre.sh" ]; then
         # shellcheck source=/dev/null
-        source "$USER_CONF_DIR/custom-pre.sh"
+        source "$XDG_USER_CONF_DIR/custom-pre.sh"
     fi
 }
 
@@ -283,9 +284,9 @@ postlock() {
         dunstctl set-paused false
     fi
 
-    if [ -e "$USER_CONF_DIR/custom-post.sh" ]; then
+    if [ -e "$XDG_USER_CONF_DIR/custom-post.sh" ]; then
         # shellcheck source=/dev/null
-        source "$USER_CONF_DIR/custom-post.sh"
+        source "$XDG_USER_CONF_DIR/custom-post.sh"
     fi
 }
 
@@ -847,7 +848,7 @@ usage() {
     exit 1
 }
 
-lockargs+=(-n)
+lockargs=(-n)
 
 init_config
 
@@ -855,7 +856,6 @@ init_config
 [[ "$1" = "" ]] && usage
 
 # process arguments
-lockargs=()
 for arg in "$@"; do
     [[ "${arg:0:1}" = '-' ]] || continue
 


### PR DESCRIPTION
# Description

Fix wrong override of lockerargs (#389), Execute custom-pre and post.sh only from betterlockscreen XDG-dir not ~/.config/, Prepare for v4.2.0 release

Fixes #389

# How Has This Been Tested?

Issue feedback

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
