### PR TITLE
Replaced "systemctl suspend" with "loginctl suspend"

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -20,7 +20,7 @@ init_config () {
     description=""
     quiet=false
     i3lockcolor_bin="i3lock-color"
-    suspend_command="systemctl suspend"
+    suspend_command="loginctl suspend"
 
     if ! cmd_exists "$i3lockcolor_bin" && cmd_exists "i3lock"; then
         i3lockcolor_bin="i3lock"


### PR DESCRIPTION
Changed "systemctl suspend" to "loginctl suspend" in order to make it work on non-systemd distributions (such as Artix, Devuan etc.).  As far as my knowledge goes, this should keep working normally on systemd distros and non-systemd distros by installing the elogind dependency

If this isn't an acceptable solution I understand, but support for other init systems is important.

Note: The betterlockscreen.service file will not run on systemd-free distros anyway, since it requires systemd in the first place.

# Description

Please include a summary of the changes and if applicable which issue it fixes. Please also include relevant motivation and context. If there are changes to the dependencies/min. version-constraints please mention them.

Fixes # (issue)

systemd-free linux distributions can now run this program to suspend the system.

# How Has This Been Tested?

I modified the /usr/bin/betterlockscreen file on Artix (kernel version 6.1.6-artix1-1), afterwards I also ran the "betterlockscreen -l" command several times to confirm.
I also ran a ShellCheck test.

# Please describe the tests that you ran to verify your changes.

I ran the "betterlockscreen -l" command.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)  [Didn't really see a need to put "runs without systemd" as a feature)

