### PR TITLE
Don't run dunstctl if dunst daemon isn't active

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -114,7 +114,8 @@ init_config () {
 
     # Dunst
     DUNST_INSTALLED=false && [[ -e "$(command -v dunstctl)" ]] && DUNST_INSTALLED=true
-    DUNST_IS_PAUSED=false && [[ "$DUNST_INSTALLED" == "true" ]] && DUNST_IS_PAUSED=$(dunstctl is-paused)
+    DUNST_IS_RUNNING=false && [[ "$DUNST_INSTALLED" == "true" ]] && [[ "$(pgrep -c dunst)" -gt 0 ]] && DUNST_IS_RUNNING=true
+    DUNST_IS_PAUSED=false && [[ "$DUNST_IS_RUNNING" == "true" ]] && DUNST_IS_PAUSED=$(dunstctl is-paused)
 
     # Feh
     FEH_INSTALLED=false && [[ -e "$(command -v feh)" ]] && FEH_INSTALLED=true
@@ -128,7 +129,7 @@ prelock() {
     fi
 
     # If dusnt is already paused don't pause it again
-    if [[ "$DUNST_INSTALLED" == "true" && "$DUNST_IS_PAUSED" == "false" ]]; then
+    if [[ "$DUNST_IS_RUNNING" == "true" && "$DUNST_IS_PAUSED" == "false" ]]; then
         dunstctl set-paused true
     fi
 
@@ -280,7 +281,7 @@ postlock() {
     fi
 
     # If dunst already paused before locking don't unpause dunst
-    if [[ "$DUNST_INSTALLED" == "true" && "$DUNST_IS_PAUSED" == "false" ]]; then
+    if [[ "$DUNST_IS_RUNNING" == "true" && "$DUNST_IS_PAUSED" == "false" ]]; then
         dunstctl set-paused false
     fi
 
@@ -296,11 +297,11 @@ lockinit() {
         echof error "i3lock already running"
         exit 1
     fi
-    
+
     echof act "Running prelock..."
     prelock
 
-    if [[ $runsuspend ]]; then 
+    if [[ $runsuspend ]]; then
         lockselect "$@" &
         $suspend_command
         wait $!
@@ -990,6 +991,6 @@ echof header "Betterlockscreen"
 [[ $runupdate ]] && update "${imagepaths[@]}"
 
 # Activate lockscreen
-[[ $runlock ]] && lockinit "$lockstyle" 
+[[ $runlock ]] && lockinit "$lockstyle"
 
 exit 0


### PR DESCRIPTION
# Description

Running `dunstctl` without active `dunst` daemon causes a several second delay of awaiting the DBus reply with the following message:
```
Error org.freedesktop.DBus.Error.NoReply: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
Failed to communicate with dunst, is it running? Or maybe the version is outdated. You can try 'dunstctl debug' as a next debugging step.
```

The fix adds an additional check for whether there exists a running `dunst` process in the background before running `dunstctl`.

Fixes #348

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [ ] I have made corresponding changes to the documentation (if applicable)
