### PR TITLE
feat(args): added --nofx arg to disable effects

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -314,6 +314,7 @@ lockinit() {
 
 lockselect() {
     case "$1" in
+        none) if [ -f "$CUR_W_RESIZE" ]; then lock "$CUR_W_RESIZE"; else failsafe; fi ;;
         dim) if [ -f "$CUR_L_DIM" ]; then lock "$CUR_L_DIM"; else failsafe; fi ;;
         blur) if [ -f "$CUR_L_BLUR" ]; then lock "$CUR_L_BLUR"; else failsafe; fi ;;
         dimblur) if [ -f "$CUR_L_DIMBLUR" ]; then lock "$CUR_L_DIMBLUR"; else failsafe; fi ;;
@@ -446,6 +447,7 @@ resize_and_render () {
     # effects
     for effect in "${fx_list[@]}"; do
         case $effect in
+            none) continue;;
             dim) fx_dim "$RES_RESIZE" "$RES_DIM";;
             blur) fx_blur "$RES_RESIZE" "$RES_BLUR" "$resolution";;
             dimblur) fx_dimblur "$RES_RESIZE" "$RES_DIMBLUR" "$resolution";;
@@ -757,6 +759,7 @@ wallpaper() {
 
     # set wallpaper
     case "$effect" in
+        none) wallpaper="$CUR_W_RESIZE";;
         dim) wallpaper="$CUR_W_DIM";;
         blur) wallpaper="$CUR_W_BLUR";;
         dimblur) wallpaper="$CUR_W_DIMBLUR";;
@@ -811,6 +814,9 @@ usage() {
     echo
     echo "  --off <N>"
     echo "      Turn display off after N seconds"
+    echo
+    echo "  --nofx"
+    echo "      Disable all effects"
     echo
     echo "  --fx <EFFECT,EFFECT,EFFECT>"
     echo "      List of effects to generate"
@@ -924,6 +930,11 @@ for arg in "$@"; do
             keylayout="$2";
             lockargs+=(--keylayout "${keylayout:-0}")
             shift 2
+            ;;
+
+        --nofx)
+            fx_list=("none")
+            shift 1
             ;;
 
         --fx)


### PR DESCRIPTION
# Description

There is currently no option to empty out the fx list if you don't want to generate any.

# How Has This Been Tested?

Ran shellcheck and also tested the lockscreen.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
