### PR TITLE
Fix expansion for i3lock "screen" argument

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -155,7 +155,7 @@ lock() {
     $i3lockcolor_bin \
         ${image:+-i "$image"} \
         --color "$bgcolor" \
-        ${screen:+-i "$display_on"} \
+        ${display_on:+-S "$display_on"} \
         --ind-pos="x+310:y+h-80" \
         --radius=25 \
         --ring-width=5 \


### PR DESCRIPTION
# Description

#411 introduced a regression where the `--display` argument is never passed properly to i3lock's `--screen/-S` argument.

`screen` is never defined so the expansion always fails. The expanded form would have also passed an `-i` argument again so no image would have been loaded.

# How Has This Been Tested?

Ran shellcheck and ran `betterlockscreen` with `--display 1` and again with `--display 2`.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
