### PR TITLE
Fallback to convert if magick is unavailable

### DIFF
--- a/betterlockscreen
+++ b/betterlockscreen
@@ -21,9 +21,16 @@ init_config () {
     quiet=false
     i3lockcolor_bin="i3lock-color"
     suspend_command="systemctl suspend"
+    convert_command="magick"
+    composite_command="magick composite"
 
     if ! cmd_exists "$i3lockcolor_bin" && cmd_exists "i3lock"; then
         i3lockcolor_bin="i3lock"
+    fi
+
+    if ! cmd_exists "magick"; then
+        convert_command="convert"
+        composite_command="composite"
     fi
 
     # default theme
@@ -404,7 +411,7 @@ base_resize() {
     local size="$3"
 
     echof act "Resizing base image..."
-    eval magick "$input" \
+    eval $convert_command "$input" \
         -resize "$size""^" \
         -gravity center \
         -extent "$size" \
@@ -417,7 +424,7 @@ fx_dim() {
     local output="$2"
 
     echof act "Rendering 'dim' effect..."
-    eval magick "$input" \
+    eval $convert_command "$input" \
         -fill black -colorize "$dim_level"% \
         "$output"
 }
@@ -431,7 +438,7 @@ fx_blur() {
     echof act "Rendering 'blur' effect..."
     blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
     blur_sigma=$(echo "scale=2; 0.6 * $blur_level" | bc)
-    eval magick "$input" \
+    eval $convert_command "$input" \
         -filter Gaussian \
         -resize "$blur_shrink%" \
         -define "filter:sigma=$blur_sigma" \
@@ -448,7 +455,7 @@ fx_dimblur() {
     echof act "Rendering 'dimblur' effect..."
     blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
     blur_sigma=$(echo "scale=2; 0.6 * $blur_level" | bc)
-    eval magick "$input" \
+    eval $convert_command "$input" \
         -fill black -colorize "$dim_level"% \
         -filter Gaussian \
         -resize "$blur_shrink%" \
@@ -464,7 +471,7 @@ fx_pixel() {
 
     echof act "Rendering 'pixel' effect..."
     IFS=',' read -ra range <<< "$pixel_scale"
-    eval magick "$input" \
+    eval $convert_command "$input" \
         -scale "${range[0]}"% -scale "${range[1]}"% \
         "$output"
 }
@@ -476,7 +483,7 @@ fx_dimpixel() {
 
     echof act "Rendering 'dimpixel' effect..."
     IFS=',' read -ra range <<< "$pixel_scale"
-    eval magick "$input" \
+    eval $convert_command "$input" \
         -fill black -colorize "$dim_level"% \
         -scale "${range[0]}"% -scale "${range[1]}"% \
         "$output"
@@ -488,7 +495,7 @@ fx_color() {
     local size="$2"
 
     echof act "Rendering 'color' effect..."
-    eval magick -size "$size" canvas:\#"$solid_color" "$RES_COLOR"
+    eval $convert_command -size "$size" canvas:\#"$solid_color" "$RES_COLOR"
 }
 
 # create loginbox rectangle, set "$RECTANGLE"
@@ -498,13 +505,13 @@ create_loginbox () {
     local width height
     width=$(logical_px 340 1)
     height=$(logical_px 100 2)
-    magick -size "$width"x"$height" xc:\#"$loginbox" -fill none "$RECTANGLE"
-    magick "$RECTANGLE" \
+    $convert_command -size "$width"x"$height" xc:\#"$loginbox" -fill none "$RECTANGLE"
+    $convert_command "$RECTANGLE" \
         \( -clone 0 -background \#"$loginshadow" -shadow 100x5+0+0 \) +swap \
         -background none -layers merge +repage "$shadow"
-    composite -compose Dst_Out -gravity center \
+    $composite_command -compose Dst_Out -gravity center \
         "$RECTANGLE" "$shadow" -alpha Set "$shadow"
-    magick "$shadow" "$RECTANGLE" -geometry +10+10 -composite "$RECTANGLE"
+    $convert_command "$shadow" "$RECTANGLE" -geometry +10+10 -composite "$RECTANGLE"
     [[ "$shadow" ]] && rm "$shadow"
 }
 
@@ -512,13 +519,13 @@ create_loginbox () {
 create_description () {
     DESCRECT="$CUR_DIR/description.png"
     local shadow="$CUR_DIR/shadow.png"
-    magick -background none -family "$(fc-match "$font" family)" -style Normal -pointsize 14 -fill \#"$greetercolor" label:"\ $description\ " -bordercolor \#"$loginbox" -border 10 "$DESCRECT"
-    magick "$DESCRECT" \
+    $convert_command -background none -family "$(fc-match "$font" family)" -style Normal -pointsize 14 -fill \#"$greetercolor" label:"\ $description\ " -bordercolor \#"$loginbox" -border 10 "$DESCRECT"
+    $convert_command "$DESCRECT" \
         \( -clone 0 -background \#"$loginshadow" -shadow 100x5+0+0 \) +swap \
         -background none -layers merge +repage "$shadow"
-    composite -compose Dst_Out -gravity center \
+    $composite_command -compose Dst_Out -gravity center \
         "$DESCRECT" "$shadow" -alpha Set "$shadow"
-    magick "$shadow" "$DESCRECT" -geometry +10+10 -composite "$DESCRECT"
+    $convert_command "$shadow" "$DESCRECT" -geometry +10+10 -composite "$DESCRECT"
     [[ "$shadow" ]] && rm "$shadow"
 }
 
@@ -638,22 +645,22 @@ update () {
         [[ -f "$RES_COLOR" ]] && eval "cp $RES_COLOR $CUR_W_COLOR"
     else
         echof act "Creating canvas: $TOTAL_SIZE"
-        [[ -f "$RES_RESIZE" ]] && eval "magick -size $TOTAL_SIZE 'xc:blue' $CUR_W_RESIZE"
-        [[ -f "$RES_DIM" ]] && eval "magick -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIM"
-        [[ -f "$RES_BLUR" ]] && eval "magick -size $TOTAL_SIZE 'xc:blue' $CUR_W_BLUR"
-        [[ -f "$RES_DIMBLUR" ]] && eval "magick -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIMBLUR"
-        [[ -f "$RES_PIXEL" ]] && eval "magick -size $TOTAL_SIZE 'xc:blue' $CUR_W_PIXEL"
-        [[ -f "$RES_DIMPIXEL" ]] && eval "magick -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIMPIXEL"
-        [[ -f "$RES_COLOR" ]] && eval "magick -size $TOTAL_SIZE 'xc:blue' $CUR_W_COLOR"
+        [[ -f "$RES_RESIZE" ]] && eval "$convert_command -size $TOTAL_SIZE 'xc:blue' $CUR_W_RESIZE"
+        [[ -f "$RES_DIM" ]] && eval "$convert_command -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIM"
+        [[ -f "$RES_BLUR" ]] && eval "$convert_command -size $TOTAL_SIZE 'xc:blue' $CUR_W_BLUR"
+        [[ -f "$RES_DIMBLUR" ]] && eval "$convert_command -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIMBLUR"
+        [[ -f "$RES_PIXEL" ]] && eval "$convert_command -size $TOTAL_SIZE 'xc:blue' $CUR_W_PIXEL"
+        [[ -f "$RES_DIMPIXEL" ]] && eval "$convert_command -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIMPIXEL"
+        [[ -f "$RES_COLOR" ]] && eval "$convert_command -size $TOTAL_SIZE 'xc:blue' $CUR_W_COLOR"
 
         echof act "Rendering final wallpaper images..."
-        [[ -f "$CUR_W_RESIZE" ]] && eval "magick $CUR_W_RESIZE $PARAM_RESIZE $CUR_W_RESIZE"
-        [[ -f "$CUR_W_DIM" ]] && eval "magick $CUR_W_DIM $PARAM_DIM $CUR_W_DIM"
-        [[ -f "$CUR_W_BLUR" ]] && eval "magick $CUR_W_BLUR $PARAM_BLUR $CUR_W_BLUR"
-        [[ -f "$CUR_W_DIMBLUR" ]] && eval "magick $CUR_W_DIMBLUR $PARAM_DIMBLUR $CUR_W_DIMBLUR"
-        [[ -f "$CUR_W_PIXEL" ]] && eval "magick $CUR_W_PIXEL $PARAM_PIXEL $CUR_W_PIXEL"
-        [[ -f "$CUR_W_DIMPIXEL" ]] && eval "magick $CUR_W_DIMPIXEL $PARAM_DIMPIXEL $CUR_W_DIMPIXEL"
-        [[ -f "$CUR_W_COLOR" ]] && eval "magick $CUR_W_COLOR $PARAM_COLOR $CUR_W_COLOR"
+        [[ -f "$CUR_W_RESIZE" ]] && eval "$convert_command $CUR_W_RESIZE $PARAM_RESIZE $CUR_W_RESIZE"
+        [[ -f "$CUR_W_DIM" ]] && eval "$convert_command $CUR_W_DIM $PARAM_DIM $CUR_W_DIM"
+        [[ -f "$CUR_W_BLUR" ]] && eval "$convert_command $CUR_W_BLUR $PARAM_BLUR $CUR_W_BLUR"
+        [[ -f "$CUR_W_DIMBLUR" ]] && eval "$convert_command $CUR_W_DIMBLUR $PARAM_DIMBLUR $CUR_W_DIMBLUR"
+        [[ -f "$CUR_W_PIXEL" ]] && eval "$convert_command $CUR_W_PIXEL $PARAM_PIXEL $CUR_W_PIXEL"
+        [[ -f "$CUR_W_DIMPIXEL" ]] && eval "$convert_command $CUR_W_DIMPIXEL $PARAM_DIMPIXEL $CUR_W_DIMPIXEL"
+        [[ -f "$CUR_W_COLOR" ]] && eval "$convert_command $CUR_W_COLOR $PARAM_COLOR $CUR_W_COLOR"
     fi
 
     echof act "Rendering final lockscreen images..."
@@ -670,13 +677,13 @@ update () {
         done
     fi
 
-    [[ -f "$CUR_W_RESIZE" ]] && eval "magick $CUR_W_RESIZE $PARAM_RECT $CUR_L_RESIZE"
-    [[ -f "$CUR_W_DIM" ]] && eval "magick $CUR_W_DIM $PARAM_RECT $CUR_L_DIM"
-    [[ -f "$CUR_W_BLUR" ]] && eval "magick $CUR_W_BLUR $PARAM_RECT $CUR_L_BLUR"
-    [[ -f "$CUR_W_DIMBLUR" ]] && eval "magick $CUR_W_DIMBLUR $PARAM_RECT $CUR_L_DIMBLUR"
-    [[ -f "$CUR_W_PIXEL" ]] && eval "magick $CUR_W_PIXEL $PARAM_RECT $CUR_L_PIXEL"
-    [[ -f "$CUR_W_DIMPIXEL" ]] && eval "magick $CUR_W_DIMPIXEL $PARAM_RECT $CUR_L_DIMPIXEL"
-    [[ -f "$CUR_W_COLOR" ]] && eval "magick $CUR_W_COLOR $PARAM_RECT $CUR_L_COLOR"
+    [[ -f "$CUR_W_RESIZE" ]] && eval "$convert_command $CUR_W_RESIZE $PARAM_RECT $CUR_L_RESIZE"
+    [[ -f "$CUR_W_DIM" ]] && eval "$convert_command $CUR_W_DIM $PARAM_RECT $CUR_L_DIM"
+    [[ -f "$CUR_W_BLUR" ]] && eval "$convert_command $CUR_W_BLUR $PARAM_RECT $CUR_L_BLUR"
+    [[ -f "$CUR_W_DIMBLUR" ]] && eval "$convert_command $CUR_W_DIMBLUR $PARAM_RECT $CUR_L_DIMBLUR"
+    [[ -f "$CUR_W_PIXEL" ]] && eval "$convert_command $CUR_W_PIXEL $PARAM_RECT $CUR_L_PIXEL"
+    [[ -f "$CUR_W_DIMPIXEL" ]] && eval "$convert_command $CUR_W_DIMPIXEL $PARAM_RECT $CUR_L_DIMPIXEL"
+    [[ -f "$CUR_W_COLOR" ]] && eval "$convert_command $CUR_W_COLOR $PARAM_RECT $CUR_L_COLOR"
 
     [[ "$RECTANGLE" ]] && rm "$RECTANGLE"
     [[ "$DESCRECT" ]] && rm "$DESCRECT"
@@ -900,7 +907,7 @@ for arg in "$@"; do
             echo
             echo "Betterlockscreen: version: v$VERSION (dunst: $DUNST_INSTALLED, feh: $FEH_INSTALLED)"
             $i3lockcolor_bin --version
-            magick --version
+            $convert_command --version
 
             if [[ "$DUNST_INSTALLED" == "true" ]]; then
                 dunstctl debug


### PR DESCRIPTION
# Description

I added variables for both `convert` and `composite` command that both use the `magick` utility if it's available but then falls back to the commands themselves.

Fixes https://github.com/betterlockscreen/betterlockscreen/discussions/422#discussioncomment-9842171

# How Has This Been Tested?

My system has ImageMagick 7 installed and also includes `convert -> magick` and `composite -> magick` symlinks so I just renamed the `magick` binary to something else and re-linked the symlinks to those to check. I then regenerated all the effects.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
