### PR TITLE
Create betterlockscreen.sh

### DIFF
--- a/betterlockscreen.sh
+++ b/betterlockscreen.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Function to apply the blur effect with custom blur strength
+apply_custom_blur() {
+    blur_strength="$1"  # Get user-specified blur intensity
+    image="$2"          # Input image
+    output_image="$3"   # Output image
+
+    # Apply the blur effect using ImageMagick
+    convert "$image" -blur 0x"$blur_strength" "$output_image"
+}
+
+# Default values
+blur_strength=8  # Default blur strength if not provided
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --lock)
+            lock_screen=true
+            shift
+            ;;
+        --blur-strength)
+            blur_strength="$2"
+            shift
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Example lockscreen logic
+if [ "$lock_screen" = true ]; then
+    # Set the input and output images
+    input_image="/path/to/cached_image.png"  # Cached lockscreen image
+    output_image="/path/to/lockscreen_output.png"
+
+    # Apply the custom blur effect
+    apply_custom_blur "$blur_strength" "$input_image" "$output_image"
+
+    # Lock the screen using i3lock
+    i3lock -i "$output_image"
+fi


### PR DESCRIPTION
Explanation:

apply_custom_blur: A function to apply a custom blur strength using ImageMagick's convert command.

Command-line arguments:

--lock: Triggers the lock screen with a blurred image.

--blur-strength <value>: Allows the user to specify the strength of the blur (default is 8).


The script will apply the blur effect to the cached image and then lock the screen using i3lock.


Example usage:

betterlockscreen --lock --blur-strength 12

This command locks the screen using a blur strength of 12.

# Description

Please include a summary of the changes and if applicable which issue it fixes. Please also include relevant motivation and context. If there are changes to the dependencies/min. version-constraints please mention them.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:

- [x] I have performed a self-review of my own code/checked that ShellCheck succeeds
- [x] I have made corresponding changes to the documentation (if applicable)
