### PR TITLE
Fix: Removes errant whitespace in systemd service file

### DIFF
--- a/system/betterlockscreen@.service
+++ b/system/betterlockscreen@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description = Lock screen when going to sleep/suspend
+Description=Lock screen when going to sleep/suspend
 Before=sleep.target
 Before=suspend.target
 


### PR DESCRIPTION
# Description
Removes problematic whitespace in the service file's **_Unit Description_** assignment, which causes **systemd** to error when trying to start or manage the service, as if the service does not exist or fails to instantiate.

I encountered issues after installing **betterlockscreen** from the **AUR** with **yay**. After troubleshooting, reviewing the service & journalctl logs, the errors appeared to point to the service itself. While reviewing the service file, I found a syntax issue, forked the repo, and created a patch.

I checked the repo's Issues and found that this problem was experienced by another user in an open issue  [#404](https://github.com/betterlockscreen/betterlockscreen/issues/404), and created a new, more appropriate branch that applied the corrected code.

N.B., when installing via yay, I still had to manually copy **betterlockscreen** to `/usr/local/bin/` and the service file to `/usr/lib/systemd/system/`. This is not an issue with the `install.sh` installation method, as these steps are accounted for. I am not sure if there is an issue with the AUR package, as it is out of the scope of this patch & problem.

There should be no dependency or version implications to this patch.

Fixes issue [#404](https://github.com/betterlockscreen/betterlockscreen/issues/404)

# How Has This Been Tested?
I reinstalled the AUR package, and betterlockscreen works as expected after testing its functionality & features.

# Checklist:
- [ ] I have performed a self-review of my own code/checked that ShellCheck succeeds
  - _No, as ShellCheck does not apply to systemd service files._
- [ ] I have made corresponding changes to the documentation (if applicable)
  - _No documentation changes are necessary._